### PR TITLE
Valid CF resource names

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,11 +53,6 @@ class MetricPlugin {
         /**
          * @type {string}
          */
-        this.stage = options.stage;
-
-        /**
-         * @type {string}
-         */
         this.service = serverless.service.service;
 
         /**
@@ -69,6 +64,11 @@ class MetricPlugin {
          * @type {object}
          */
         this.provider = serverless.getProvider('aws');
+
+        /**
+         * @type {string}
+         */
+        this.stage = this.provider.getStage();
 
         /**
          * @type {MetricOption[]}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 
-const pascalcase = require('pascalcase');
-
 /**
  * ABSTRACT PLUGIN TYPE DEFINITIONS
  * 
@@ -66,6 +64,11 @@ class MetricPlugin {
          * @type {object}
          */
         this.serverless = serverless;
+
+        /**
+         * @type {object}
+         */
+        this.provider = serverless.getProvider('aws');
 
         /**
          * @type {MetricOption[]}
@@ -138,7 +141,7 @@ class MetricPlugin {
         const resource = {
             __metricOption: metricOptions,
             Type: 'AWS::Logs::MetricFilter',
-            DependsOn: `${pascalcase(functionName)}LogGroup`,
+            DependsOn: this.provider.naming.getLogGroupLogicalId(functionName),
             Properties: {
                 FilterPattern: pattern,
                 LogGroupName: logGroupName,
@@ -165,7 +168,8 @@ class MetricPlugin {
         if (!this.serverless.service.provider.compiledCloudFormationTemplate.Resources) {
             this.serverless.service.provider.compiledCloudFormationTemplate.Resources = {};
         }
-        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[name] = resource;
+        const normalizedName = this.provider.naming.normalizeNameToAlphaNumericOnly(name);
+        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[normalizedName] = resource;
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "serverless-plugin-metric",
+  "version": "1.1.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,5 @@
   ],
   "author": "Alexandros Fotiadis <fotiadis90@gmail.com>",
   "license": "ISC",
-  "dependencies": {
-    "pascalcase": "^0.1.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Fixes #2 
When function name contains dash or underscores, generated resource names weren't working.
Also, I've used the stage from `provider` instead of `options`, so it's working if we don't specify the stage in the CLI.
