### PR TITLE
Fix: `this.provider.getStage()` not available in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,11 +66,6 @@ class MetricPlugin {
         this.provider = serverless.getProvider('aws');
 
         /**
-         * @type {string}
-         */
-        this.stage = this.provider.getStage();
-
-        /**
          * @type {MetricOption[]}
          */
         this.metricOptions = serverless.service.custom && serverless.service.custom.metrics
@@ -132,8 +127,9 @@ class MetricPlugin {
      */
     createAWSMetricResource(functionName, metricOptions) {
         const { name, namespace, pattern, value = '1' } = metricOptions;
-        const logGroupName = `/aws/lambda/${this.service}-${this.stage}-${functionName}`;
-        const dynamicNamespace = `${this.service}/${this.stage}`;
+        const stage = this.provider.getStage();
+        const logGroupName = `/aws/lambda/${this.service}-${stage}-${functionName}`;
+        const dynamicNamespace = `${this.service}/${stage}`;
 
         /**
          * @type {AWSMetricFilterResource}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "serverless-plugin-metric",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-metric",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simplified way to create AWSL:Logs:MetricFilter resources using custom pattern-filter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In #4, I switched to get the stage dynamically using `this.provider.getStage()`. But this is not available in the constructor yet, which leads in some cases to the following CloudFormation error:

> An error occurred: MyserviceMetricFilterattempts - 2 validation errors detected: Value 'my-service/${opt:stage, 'staging'}' at 'metricTransformations.1.member.metricNamespace' failed to satisfy constraint: Member must satisfy regular expression pattern: [^:*$]*; Value '/aws/lambda/my-service-${opt:stage, 'staging'}-the-lambda' at 'logGroupName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\.\-_/#A-Za-z0-9]+

The reason is that stage is not resolved yet in the constructor. I changed to do the getStage dynamically instead.